### PR TITLE
Fix issues in DateTimePicker when parent uses "OnPush" change detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Gentics UI Core Changelog
 
+### 6.0.3 (in progress)
+
+### Fixes
+
+* Fix display value not updated in DateTimePicker component when parent component uses "OnPush" change detection. GUIC-160
+
+
 ### 6.0.2 (2018-01-09)
 
 ### Fixes

--- a/src/components/date-time-picker/date-time-picker.component.ts
+++ b/src/components/date-time-picker/date-time-picker.component.ts
@@ -1,4 +1,5 @@
-import {ChangeDetectorRef, Component, EventEmitter, forwardRef, Input, OnDestroy, OnInit, Optional, Output} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, forwardRef, Input, OnDestroy, OnInit,
+    Optional, Output} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {Subscription} from 'rxjs/Subscription';
 
@@ -31,7 +32,8 @@ const GTX_DATEPICKER_VALUE_ACCESSOR = {
 @Component({
     selector: 'gtx-date-time-picker',
     templateUrl: './date-time-picker.tpl.html',
-    providers: [GTX_DATEPICKER_VALUE_ACCESSOR]
+    providers: [GTX_DATEPICKER_VALUE_ACCESSOR],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DateTimePicker implements ControlValueAccessor, OnInit, OnDestroy {
     /** Sets the date picker to be auto-focused. Handled by `AutofocusDirective`. */
@@ -93,7 +95,7 @@ export class DateTimePicker implements ControlValueAccessor, OnInit, OnDestroy {
     _clearable: boolean = false;
     _selectYear: boolean = false;
     _disabled: boolean = false;
-    displayValue: string = ' ';
+    displayValue: string = '';
     /** @internal */
     private value: momentjs.Moment;
 
@@ -202,15 +204,21 @@ export class DateTimePicker implements ControlValueAccessor, OnInit, OnDestroy {
         } else {
             this.displayValue = this.formatProvider.format(this.value, this._displayTime, this._displaySeconds);
         }
+
+        this.changeDetector.markForCheck();
     }
 
     /** Clear input value of DateTimePicker and emit `emptyValue` as value. */
     clearDateTime(): void {
         this.displayValue = '';
         this.value = undefined;
+
         const emptyValue = this.emptyValue;
         this.clear.emit(emptyValue);
         this.onChange(emptyValue);
         this.change.emit(emptyValue);
+
+        this.changeDetector.markForCheck();
     }
+
 }


### PR DESCRIPTION
When the DateTimePicker Component is used inside of other components with "OnPush" change detection, the display value was not updated. This fix enables the "OnPush" change detection strategy on the whole DateTimePicker Component and manually marks changes of it's internal state in the change detection.  