### PR TITLE
SUP-6172: Fixed format-provider override for Components and locale change detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Gentics UI Core Changelog
 
-## 6.1.2 (not yet released)
+## 6.2.0 (2018-08-30)
+
+### Features
+
+* Add support to override the DateTimeFormatProvider on the DateTimePickerControl-Component (SUP-6172)
+
+### Fixes
+
+* Fix change-detection and update of the calendar in the DateTimePickerControl when a FormatProvider pushes changes (SUP-6172)
+
+## 6.1.2 (2018-08-14)
 
 ### Fixes
 
 * Fix occasional incorrect height calculation of Textarea (GUIC-152).
-* Added support to override the DateTimeFormatProvider on the DateTimePickerControl-Component (SUP-6172)
-* Fixed change-detection and update of the calendar when a FormatProvider pushes changes (SUP-6172)
 
 ## 6.1.1 (2018-04-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 * Fix occasional incorrect height calculation of Textarea (GUIC-152).
+* Added support to override the DateTimeFormatProvider on the DateTimePickerControl-Component (SUP-6172)
+* Fixed change-detection and update of the calendar when a FormatProvider pushes changes (SUP-6172)
 
 ## 6.1.1 (2018-04-11)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gentics-ui-core",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3234,7 +3234,8 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -3267,6 +3268,7 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "0.4.2",
             "concat-map": "0.0.1"
@@ -3308,7 +3310,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -3422,7 +3425,8 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fstream": {
           "version": "1.0.11",
@@ -3484,6 +3488,7 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3536,7 +3541,8 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -3553,6 +3559,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -3677,6 +3684,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "1.1.7"
           }
@@ -3794,7 +3802,8 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -3889,6 +3898,7 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "7.1.2"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gentics-ui-core",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "description": "Gentics UI Core Framework",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/components/date-time-picker/date-time-picker-controls.component.ts
+++ b/src/components/date-time-picker/date-time-picker-controls.component.ts
@@ -11,7 +11,7 @@ import {DateTimePickerFormatProvider} from './date-time-picker-format-provider.s
 import {coerceToBoolean} from '../../common/coerce-to-boolean';
 import * as momentjs from 'moment';
 
-/**
+/*
  * Rome is a date picker widget: https://github.com/bevacqua/rome
  *
  * Note that Rome comes with its own (outdated) version of Moment.js, which we do not want to use.

--- a/src/components/date-time-picker/date-time-picker-controls.component.ts
+++ b/src/components/date-time-picker/date-time-picker-controls.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, EventEmitter, HostBinding, Input, OnDestroy, Output, SimpleChanges, ViewChild} from '@angular/core';
+import {Component, ElementRef, EventEmitter, HostBinding, Input, OnDestroy, Output, SimpleChanges, ViewChild, Optional} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
 import 'rxjs/add/operator/concat';
@@ -48,7 +48,7 @@ export class DateTimePickerControls implements OnDestroy {
     /**
      * Set to overwrite texts and date formatting in the modal.
      */
-    @Input() formatProvider: DateTimePickerFormatProvider = new DateTimePickerFormatProvider();
+    @Input() formatProvider: DateTimePickerFormatProvider;
 
     /**
      * The minimum date allowable. E.g. `new Date(2015, 2, 12)`
@@ -134,7 +134,16 @@ export class DateTimePickerControls implements OnDestroy {
     };
     private subscription: Subscription;
 
+    constructor(@Optional() private defaultFormatProvider: DateTimePickerFormatProvider) {}
+
     ngOnInit(): void {
+        if (this.defaultFormatProvider == null) {
+            this.defaultFormatProvider = new DateTimePickerFormatProvider();
+        }
+        if (this.formatProvider == null) {
+            this.formatProvider = this.defaultFormatProvider;
+        }
+
         this.value = momentjs.unix(Number(this.timestamp));
 
         // Update strings and date format when format provider emits a change

--- a/src/components/date-time-picker/date-time-picker-controls.spec.ts
+++ b/src/components/date-time-picker/date-time-picker-controls.spec.ts
@@ -287,7 +287,7 @@ describe('DateTimePickerControls', () => {
 
     describe('l10n/i18n - No Provider override:', () => {
 
-        fit('should default to normal strings',
+        it('should default to normal strings',
             pickerTest(picker => {
                 const provider = picker.formatProvider;
                 expect(provider).toBeDefined;
@@ -295,7 +295,7 @@ describe('DateTimePickerControls', () => {
             })
         );
 
-        fit('should use the provider from input',
+        it('should use the provider from input',
             componentTest(() => TestComponent, `
                 <gtx-date-time-picker-controls [formatProvider]="provider">
                 </gtx-date-time-picker-controls>`,
@@ -318,7 +318,7 @@ describe('DateTimePickerControls', () => {
             formatProviderToUse = formatProvider = new TestFormatProvider();
         });
 
-        fit('should use the provider-override strings',
+        it('should use the provider-override strings',
             pickerTest(picker => {
                 const provider = picker.formatProvider;
                 expect(provider).toBeDefined;

--- a/src/components/date-time-picker/date-time-picker-controls.spec.ts
+++ b/src/components/date-time-picker/date-time-picker-controls.spec.ts
@@ -8,6 +8,8 @@ import {DateTimePickerControls} from './date-time-picker-controls.component';
 import {InputField} from '../input/input.component';
 import {Button} from '../button/button.component';
 import {DateTimePickerFormatProvider} from './date-time-picker-format-provider.service';
+import {DateTimePickerStrings} from './date-time-picker-strings';
+import {defaultStrings} from './date-time-picker-default-strings';
 
 const TEST_TIMESTAMP: number = 1457971763;
 let formatProviderToUse: DateTimePickerFormatProvider = null;
@@ -240,63 +242,105 @@ describe('DateTimePickerControls', () => {
 
     describe('time increments:', () => {
 
-        function incrementDecrementTest(testFn: (picker: DateTimePickerControls) => void): any {
-            return componentTest(() => TestComponent, `<gtx-date-time-picker-controls
-                            timestamp="${TEST_TIMESTAMP}"
-                            (change)="onChange($event)">
-                        </gtx-date-time-picker-controls>`,
-                fixture => {
-                    const picker = fixture.debugElement.query(By.directive(DateTimePickerControls)).componentInstance;
-                    fixture.detectChanges();
-                    tick();
-                    testFn(picker);
-                }
-            );
-        }
-
         it('incrementTime("seconds") increments the time by one second',
-            incrementDecrementTest(picker => {
+            pickerTest(picker => {
                 picker.incrementTime('seconds');
                 expect(picker.getUnixTimestamp()).toBe(TEST_TIMESTAMP + 1);
             })
         );
 
         it('incrementTime("minutes") increments the time by one minute',
-            incrementDecrementTest(picker => {
+            pickerTest(picker => {
                 picker.incrementTime('minutes');
                 expect(picker.getUnixTimestamp()).toBe(TEST_TIMESTAMP + 60);
             })
         );
 
         it('incrementTime("hours") increments the time by one hour',
-            incrementDecrementTest(picker => {
+            pickerTest(picker => {
                 picker.incrementTime('hours');
                 expect(picker.getUnixTimestamp()).toBe(TEST_TIMESTAMP + (60 * 60));
             })
         );
 
         it('decrementTime("seconds") decrement the time by one second',
-            incrementDecrementTest(picker => {
+            pickerTest(picker => {
                 picker.decrementTime('seconds');
                 expect(picker.getUnixTimestamp()).toBe(TEST_TIMESTAMP - 1);
             })
         );
 
         it('decrementTime("minutes") decrements the time by one minute',
-            incrementDecrementTest(picker => {
+            pickerTest(picker => {
                 picker.decrementTime('minutes');
                 expect(picker.getUnixTimestamp()).toBe(TEST_TIMESTAMP - 60);
             })
         );
 
         it('decrementTime("hours") decrements the time by one hour',
-            incrementDecrementTest(picker => {
+            pickerTest(picker => {
                 picker.decrementTime('hours');
                 expect(picker.getUnixTimestamp()).toBe(TEST_TIMESTAMP - (60 * 60));
             })
         );
     });
+
+    describe('l10n/i18n - No Provider override:', () => {
+
+        fit('should default to normal strings',
+            pickerTest(picker => {
+                const provider = picker.formatProvider;
+                expect(provider).toBeDefined;
+                expect(provider.strings).toEqual(defaultStrings);
+            })
+        );
+
+        fit('should use the provider from input',
+            componentTest(() => TestComponent, `
+                <gtx-date-time-picker-controls [formatProvider]="provider">
+                </gtx-date-time-picker-controls>`,
+                fixture => {
+                    const picker = fixture.debugElement.query(By.directive(DateTimePickerControls)).componentInstance;
+                    fixture.detectChanges();
+                    tick();
+                    const provider = picker.formatProvider;
+                    expect(provider).toBeDefined;
+                    expect(provider.strings).toEqual(timePickerTestStrings);
+                }
+            )
+        );
+    });
+
+    describe('l10n/i18n - Provider override:', () => {
+
+        let formatProvider: TestFormatProvider;
+        beforeEach(() => {
+            formatProviderToUse = formatProvider = new TestFormatProvider();
+        });
+
+        fit('should use the provider-override strings',
+            pickerTest(picker => {
+                const provider = picker.formatProvider;
+                expect(provider).toBeDefined;
+                expect(provider.strings).toEqual(timePickerTestStrings);
+            })
+        );
+    });
 });
+
+function pickerTest(testFn: (picker: DateTimePickerControls) => void): any {
+    return componentTest(() => TestComponent, `<gtx-date-time-picker-controls
+                    timestamp="${TEST_TIMESTAMP}"
+                    (change)="onChange($event)">
+                </gtx-date-time-picker-controls>`,
+        fixture => {
+            const picker = fixture.debugElement.query(By.directive(DateTimePickerControls)).componentInstance;
+            fixture.detectChanges();
+            tick();
+            testFn(picker);
+        }
+    );
+}
 
 @Component({
     selector: 'test-component',
@@ -307,6 +351,24 @@ class TestComponent {
     max: any;
     timestamp = TEST_TIMESTAMP;
     onChange = jasmine.createSpy('onChange');
+    provider = new TestFormatProvider();
+}
+
+const timePickerTestStrings: DateTimePickerStrings = {
+    hours: '_test_hours_',
+    minutes: '_test_minutes_',
+    seconds: '_test_seconds_',
+    cancel: '_test_cancel_',
+    months: ['_test_january_', '_test_february_', '_test_march_', '_test_april_', '_test_may_', '_test_june_', '_test_july_', '_test_august_', '_test_september_', '_test_october_', '_test_november_', '_test_december_'],
+    monthsShort: ['_test_jan_', '_test_feb_', '_test_mar_', '_test_apr_', '_test_may_', '_test_jun_', '_test_jul_', '_test_aug_', '_test_sep_', '_test_oct_', '_test_nov_', '_test_dec_'],
+    okay: '_test_okay_',
+    weekdays: ['_test_sunday_', '_test_monday_', '_test_tuesday_', '_test_wednesday_', '_test_thursday_', '_test_friday_', '_test_saturday_'],
+    weekdaysShort: ['_test_sun_', '_test_mon_', '_test_tue_', '_test_wed_', '_test_thu_', '_test_fri_', '_test_sat_'],
+    weekdaysMin: ['_test_su_', '_test_mo_', '_test_tu_', '_test_we_', '_test_th_', '_test_fr_', '_test_sa_'],
+};
+
+class TestFormatProvider extends DateTimePickerFormatProvider {
+    strings = timePickerTestStrings;
 }
 
 @Component({

--- a/src/docs/pages/date-time-picker-controls-demo/date-time-picker-controls-demo.tpl.html
+++ b/src/docs/pages/date-time-picker-controls-demo/date-time-picker-controls-demo.tpl.html
@@ -91,5 +91,6 @@
                 <gtx-date-time-picker-controls demo-format-provider
                                             [timestamp]="timestamp"></gtx-date-time-picker-controls>
         '></gtx-highlighted-code>
+        <gtx-highlighted-code language="TypeScript" [code]="demoProviderSource"></gtx-highlighted-code>
     </div>
 </gtx-demo-block>

--- a/src/docs/pages/date-time-picker-controls-demo/date-time-picker-controls-demo.tpl.html
+++ b/src/docs/pages/date-time-picker-controls-demo/date-time-picker-controls-demo.tpl.html
@@ -80,17 +80,17 @@
 <gtx-demo-block demoTitle="Using a Format-Provider">
     <div class="demo-result">
         <p>
-            The controls can take in a format-provider either via it's @Input <code>formatProvider</code> or by overriding the DateTimePickerFormatProvider.
+            The controls can take in a format-provider either via their <code>formatProvider</code> @Input property or by overriding the DateTimePickerFormatProvider.
             A detailed description is in the  <a href="#/date-time-picker">DateTimePicker documentation</a>.
         </p>
         <gtx-date-time-picker-controls demo-format-provider
                                        [timestamp]="timestamp"></gtx-date-time-picker-controls>
     </div>
     <div class="demo-code">
+        <gtx-highlighted-code language="TypeScript" [code]="demoProviderSource"></gtx-highlighted-code>
         <gtx-highlighted-code language="HTML" code='
                 <gtx-date-time-picker-controls demo-format-provider
                                             [timestamp]="timestamp"></gtx-date-time-picker-controls>
         '></gtx-highlighted-code>
-        <gtx-highlighted-code language="TypeScript" [code]="demoProviderSource"></gtx-highlighted-code>
     </div>
 </gtx-demo-block>

--- a/src/docs/pages/date-time-picker-controls-demo/date-time-picker-controls-demo.tpl.html
+++ b/src/docs/pages/date-time-picker-controls-demo/date-time-picker-controls-demo.tpl.html
@@ -76,3 +76,20 @@
         '></gtx-highlighted-code>
     </div>
 </gtx-demo-block>
+
+<gtx-demo-block demoTitle="Using a Format-Provider">
+    <div class="demo-result">
+        <p>
+            The controls can take in a format-provider either via it's @Input <code>formatProvider</code> or by overriding the DateTimePickerFormatProvider.
+            A detailed description is in the  <a href="#/date-time-picker">DateTimePicker documentation</a>.
+        </p>
+        <gtx-date-time-picker-controls demo-format-provider
+                                       [timestamp]="timestamp"></gtx-date-time-picker-controls>
+    </div>
+    <div class="demo-code">
+        <gtx-highlighted-code language="HTML" code='
+                <gtx-date-time-picker-controls demo-format-provider
+                                            [timestamp]="timestamp"></gtx-date-time-picker-controls>
+        '></gtx-highlighted-code>
+    </div>
+</gtx-demo-block>

--- a/src/docs/pages/date-time-picker-controls-demo/date-time-picker-controls-demo.ts
+++ b/src/docs/pages/date-time-picker-controls-demo/date-time-picker-controls-demo.ts
@@ -9,6 +9,7 @@ const TWO_WEEKS_HENCE = Date.now() + TWO_WEEKS;
 })
 export class DateTimePickerControlsDemo {
     componentSource: string = require('!!raw-loader!../../../components/date-time-picker/date-time-picker-controls.component.ts');
+    demoProviderSource = (require('!!raw-loader!../date-time-picker-demo/demo-format-provider.ts') as string).split('\n').slice(3).join('\n');
     timestamp: number = Math.round(Date.now() / 1000);
     min = new Date(TWO_WEEKS_AGO);
     max = new Date(TWO_WEEKS_HENCE);

--- a/src/docs/pages/date-time-picker-demo/date-time-picker-demo.tpl.html
+++ b/src/docs/pages/date-time-picker-demo/date-time-picker-demo.tpl.html
@@ -103,33 +103,7 @@
         <gtx-date-time-picker demo-format-provider [timestamp]="timestamp"></gtx-date-time-picker>
     </div>
     <div class="demo-code">
-        <gtx-highlighted-code language="TypeScript" code="
-                @Directive({
-                    selector: '[demo-format-provider]',
-                    providers: [{
-                        provide: DateTimePickerFormatProvider,
-                        useExisting: forwardRef(() => DemoFormatProvider)
-                    }]
-                })
-                export class DemoFormatProvider extends DateTimePickerFormatProvider {
-
-                    strings: DateTimePickerStrings = {
-                        hours: 'Stunde',
-                        minutes: 'Minute',
-                        seconds: 'Sekunde',
-                        months: ['Januar', 'Februar', 'März', '...'],
-                        monthsShort: ['Jan', 'Feb', 'Mär', '...'],
-                        weekdays: ['Sonntag', 'Montag', 'Dienstag', '...'],
-                        weekdaysShort: ['So', 'Mo', 'Di', '...'],
-                        cancel: 'Abbrechen',
-                        okay: 'Okay'
-                    };
-
-                    format(moment: any, showTime: boolean, showSeconds: boolean): string {
-                        return `Tag ${moment.date()} Monat ${moment.month() + 1} Jahr ${moment.year()}`;
-                    }
-                }
-        "></gtx-highlighted-code>
+        <gtx-highlighted-code language="TypeScript" [code]="demoProviderSource"></gtx-highlighted-code>
 
         <gtx-highlighted-code language="HTML" code='
                 <gtx-date-time-picker demo-format-provider [timestamp]="timestamp">

--- a/src/docs/pages/date-time-picker-demo/date-time-picker-demo.ts
+++ b/src/docs/pages/date-time-picker-demo/date-time-picker-demo.ts
@@ -7,6 +7,7 @@ import {DemoFormatProvider} from './demo-format-provider';
 export class DateTimePickerDemo {
     componentSource: string = require('!!raw-loader!../../../components/date-time-picker/date-time-picker.component.ts');
     stringsInterfaceSource: string = require('!!raw-loader!../../../components/date-time-picker/date-time-picker-strings.ts');
+    demoProviderSource = (require('!!raw-loader!./demo-format-provider.ts') as string).split('\n').slice(3).join('\n');
 
     timestamp: number = 1457971763;
 }

--- a/src/docs/pages/date-time-picker-demo/demo-format-provider.ts
+++ b/src/docs/pages/date-time-picker-demo/demo-format-provider.ts
@@ -3,7 +3,7 @@ import {DateTimePickerFormatProvider} from '../../../components/date-time-picker
 import {DateTimePickerStrings} from '../../../components/date-time-picker/date-time-picker-strings';
 
 @Directive({
-    selector: 'gtx-date-time-picker[demo-format-provider]',
+    selector: '[demo-format-provider]',
     providers: [{ provide: DateTimePickerFormatProvider, useExisting: forwardRef(() => DemoFormatProvider) }]
 })
 export class DemoFormatProvider extends DateTimePickerFormatProvider {
@@ -34,6 +34,6 @@ export class DemoFormatProvider extends DateTimePickerFormatProvider {
     };
 
     format(moment: any, showTime: boolean, showSeconds: boolean): string {
-        return `Tag ${moment.date()} Monat ${moment.month() + 1} Jahr ${moment.year()}`; 
+        return `Tag ${moment.date()} Monat ${moment.month() + 1} Jahr ${moment.year()}`;
     }
 }

--- a/src/docs/pages/date-time-picker-demo/demo-format-provider.ts
+++ b/src/docs/pages/date-time-picker-demo/demo-format-provider.ts
@@ -9,50 +9,16 @@ import {DateTimePickerStrings} from '../../../components/date-time-picker/date-t
 export class DemoFormatProvider extends DateTimePickerFormatProvider {
 
     strings: DateTimePickerStrings = {
-        hours: "Stunde",
-        minutes: "Minute",
-        seconds: "Sekunde",
-        months: [
-            "Januar",
-            "Februar",
-            "März",
-            "April",
-            "Mai",
-            "Juni",
-            "Juli",
-            "August",
-            "September",
-            "Oktober",
-            "November",
-            "Dezember"
-        ],
-        monthsShort: [
-            "Jan",
-            "Feb",
-            "Mär",
-            "Apr",
-            "Mai",
-            "Jun",
-            "Jul",
-            "Aug",
-            "Sep",
-            "Okt",
-            "Nov",
-            "Dez"
-        ],
-        weekdays: [
-            "Sonntag",
-            "Montag",
-            "Dienstag",
-            "Mittwoch",
-            "Donnerstag",
-            "Freitag",
-            "Samstag",
-        ],
-        weekdaysShort: ["Son", "Mon", "Die", "Mit", "Don", "Fri", "Sam"],
-        weekdaysMin: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
-        cancel: "Abbrechen",
-        okay: "Okay"
+        hours: 'Stunde',
+        minutes: 'Minute',
+        seconds: 'Sekunde',
+        months: [ 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember' ],
+        monthsShort: [ 'Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez' ],
+        weekdays: [ 'Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag' ],
+        weekdaysShort: [ 'Son', 'Mon', 'Die', 'Mit', 'Don', 'Fri', 'Sam' ],
+        weekdaysMin: [ 'So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa' ],
+        cancel: 'Abbrechen',
+        okay: 'Okay'
     };
 
     format(moment: any, showTime: boolean, showSeconds: boolean): string {

--- a/src/docs/pages/date-time-picker-demo/demo-format-provider.ts
+++ b/src/docs/pages/date-time-picker-demo/demo-format-provider.ts
@@ -9,28 +9,50 @@ import {DateTimePickerStrings} from '../../../components/date-time-picker/date-t
 export class DemoFormatProvider extends DateTimePickerFormatProvider {
 
     strings: DateTimePickerStrings = {
-        hours: 'Stunde',
-        minutes: 'Minute',
-        seconds: 'Sekunde',
+        hours: "Stunde",
+        minutes: "Minute",
+        seconds: "Sekunde",
         months: [
-            'Januar',
-            'Februar',
-            'März',
-            'April',
-            'Mai',
-            'Juni',
-            'Juli',
-            'August',
-            'September',
-            'Oktober',
-            'November',
-            'Dezember'
+            "Januar",
+            "Februar",
+            "März",
+            "April",
+            "Mai",
+            "Juni",
+            "Juli",
+            "August",
+            "September",
+            "Oktober",
+            "November",
+            "Dezember"
         ],
-        monthsShort: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
-        weekdays: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag', 'Sonntag'],
-        weekdaysShort: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'],
-        cancel: 'Abbrechen',
-        okay: 'Okay'
+        monthsShort: [
+            "Jan",
+            "Feb",
+            "Mär",
+            "Apr",
+            "Mai",
+            "Jun",
+            "Jul",
+            "Aug",
+            "Sep",
+            "Okt",
+            "Nov",
+            "Dez"
+        ],
+        weekdays: [
+            "Sonntag",
+            "Montag",
+            "Dienstag",
+            "Mittwoch",
+            "Donnerstag",
+            "Freitag",
+            "Samstag",
+        ],
+        weekdaysShort: ["Son", "Mon", "Die", "Mit", "Don", "Fri", "Sam"],
+        weekdaysMin: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
+        cancel: "Abbrechen",
+        okay: "Okay"
     };
 
     format(moment: any, showTime: boolean, showSeconds: boolean): string {


### PR DESCRIPTION
- Added the DateTimePickerControl-Component provider override like the DateTimePicker-Component already allows
- Updated the change-detection of it to allow dynamic changes of the provider
- Updates the update-mechanic for rome to re-initialize it on provider-change, to update the weekdays inside the calendar
- Added tests for provider override