### PR TITLE
Fixed the scroll to view when multiple is set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.2.3 (not yet released)
 
+* Fixed the keyboard usage and search in the Select-Component when multiple option selection is enabled (GUIC-185)
+
 ### Fixes
 
 ## 6.2.2 (2018-09-11)

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -466,10 +466,13 @@ export class Select implements ControlValueAccessor {
      */
     private updateSelectedIndex(index: SelectedSelectOption): void {
         this.selectedIndex = index;
-        if (!this.multiple) {
-            const options = this.optionGroups[index[0]].options;
-            if (options && 0 <= index[1] && index[1] < options.length) {
+        const options = this.optionGroups[index[0]].options;
+
+        if (options && 0 <= index[1] && index[1] < options.length) {
+            if (!this.multiple) {
                 this.selectItem(index[0], index[1]);
+            } else {
+                this.scrollToSelectedOption();
             }
         }
     }


### PR DESCRIPTION
When using the multiple flag the options would not scroll into view when you search for them/navigate via keyboard.