### PR TITLE
ModalService use in multiple modules as provider openModals wrong.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+* Fix ModalService openModalComponents counter, when multiple instances needed. (SUP-7331)
+
 ## 6.5.0 (2019-01-15)
 
 ### Features

--- a/src/components/modal/modal.service.ts
+++ b/src/components/modal/modal.service.ts
@@ -124,14 +124,14 @@ import {IModalInstance, IDialogConfig, IModalDialog, IModalOptions} from './moda
 @Injectable()
 export class ModalService {
 
-    private openModalComponents: ComponentRef<IModalDialog>[] = [];
+    private static openModalComponents: ComponentRef<IModalDialog>[] = [];
     private getHostViewContainer: () => Promise<ViewContainerRef>;
 
     /**
      * Returns an array of ComponentRefs for each currently-opened modal.
      */
     public get openModals(): Array<ComponentRef<IModalDialog>> {
-        return this.openModalComponents;
+        return ModalService.openModalComponents;
     }
 
     constructor(private componentFactoryResolver: ComponentFactoryResolver,
@@ -192,11 +192,11 @@ export class ModalService {
                     element: componentRef.location.nativeElement,
                     open: (): Promise<any> => {
                         this.invokeOnOpenCallback(options);
-                        this.openModalComponents.push(componentRef);
+                        ModalService.openModalComponents.push(componentRef);
                         componentRef.onDestroy(() => {
-                            const index = this.openModalComponents.indexOf(componentRef);
+                            const index = ModalService.openModalComponents.indexOf(componentRef);
                             if (-1 < index) {
-                                this.openModalComponents.splice(index, 1);
+                                ModalService.openModalComponents.splice(index, 1);
                             }
                         });
                         modalWrapper.open();


### PR DESCRIPTION
Sometimes it's needed to use ModalService as provider in multiple modules, eg.: in Lazy loaded routes In this case if we want to use it, a new instance is created from the ModalService and the opened modals are counted independently. This PR fixes the problem by using DI framework possibility, to inject the parent instance and use this instance's openModals property.